### PR TITLE
docs(README.md): add tree-shaking instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ import * as Icon from "phosphor-react-native";
 <Icon.AirplaneTakeoff size="24px" mirrored={true} />
 ```
 
+In cases where tree shaking does not work (resulting in large bundle size), you can import icons individually in this format:
+
+```tsx
+// Javascript
+import Star from "phosphor-react-native/lib/commonjs/icons/Star";
+
+// Typescript
+import Star from 'phosphor-react-native/src/icons/Star';
+
+<Star size="24px" />
+```
+
 ## Related Projects
 
 - [phosphor-home](https://github.com/phosphor-icons/phosphor-home) ▲ Phosphor homepage and general info


### PR DESCRIPTION
Hi,
Thank you for creating this library, it is really helpful.

Sometimes tree shaking does not work (issue #16), I was working on an app and the bundle size was 12Mb because of this. It became 3Mb after importing individual icons with the mentioned importing syntax.

I think mentioning it in the documentation would help others. Even if the issue gets fixed it might be helpful for some edge cases.

Thanks.