### PR TITLE
build(deps): bump @phosphor-icons/core version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@phosphor-icons/core": "^2.0.2",
+    "@phosphor-icons/core": "^2.1.1",
     "caniuse-lite": "^1.0.30001518"
   },
   "devDependencies": {

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,5 +1,7 @@
 import React, { createContext } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
+import { SvgProps } from 'react-native-svg';
+
 
 export type IconWeight =
   | 'thin'
@@ -11,7 +13,7 @@ export type IconWeight =
 
 export type PaintFunction = (color: string) => React.ReactNode | null;
 
-export interface IconProps {
+export interface IconProps extends SvgProps {
   color?: string;
   size?: string | number;
   weight?: IconWeight;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1848,10 +1848,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@phosphor-icons/core@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@phosphor-icons/core/-/core-2.0.2.tgz#108c0e5d798bcb76951ae8d0a61987cd549ac949"
-  integrity sha512-ZHvHBagars5C2IGKW9TdiOe8LwIVq6/LmJRfxBlfFcbsNAfYXTNzf6IUQKy0hrPTn6bTdQh5ghe436i+W1JKrw==
+"@phosphor-icons/core@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@phosphor-icons/core/-/core-2.1.1.tgz#62a4cfbec9772f1a613a647da214fbb96f3ad39d"
+  integrity sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==
 
 "@pkgr/utils@^2.3.1":
   version "2.4.2"


### PR DESCRIPTION
# Overview
There are some newly updated icons from phosphor-icons/core, bump the @phosphor-icons/core from 2.0.2 -> 2.1.1