### PR TITLE
Change import to use type imports for React Native

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,5 +1,5 @@
 import React, { createContext } from 'react';
-import { StyleProp, TextStyle, ViewStyle } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 export type IconWeight =
   | 'thin'

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -11,15 +11,15 @@ export type IconWeight =
 
 export interface IconProps {
   color?: string;
-  size?: string | number;
-  weight?: IconWeight;
-  style?: StyleProp<ViewStyle | TextStyle>;
-  mirrored?: boolean;
-  testID?: string;
   duotoneColor?: string;
   duotoneOpacity?: number;
+  mirrored?: boolean;
+  size?: string | number;
+  style?: StyleProp<ViewStyle | TextStyle>;
+  testID?: string;
   title?: string; // SVGRProps
   titleId?: string; // SVGRProps
+  weight?: IconWeight;
 }
 
 export type Icon = React.FC<IconProps>;


### PR DESCRIPTION
# Summary

This change updates the imports of the `react-native types` to adhere to TS verbatimModuleSyntax. It looks like the same pattern is applied [icon-base.tsx](https://github.com/duongdev/phosphor-react-native/blob/main/src/lib/icon-base.tsx) as well.

**And thank you** for the wonderful library 🙇 
